### PR TITLE
New rosettampi.yaml configuration file in config_settings

### DIFF
--- a/RosettaDDGPrediction/config_settings/rosettampi.yaml
+++ b/RosettaDDGPrediction/config_settings/rosettampi.yaml
@@ -1,0 +1,31 @@
+# Default settings used in rosetta_ddg_run to set up parallel runs, 
+# set the logging level and how to find the Rosetta executables.
+
+
+################################# RUN #################################
+
+mpi:
+  # whether to use MPI
+  usempi: False
+  # MPI executable
+  mpiexec: !!null
+  # MPI arguments
+  mpiargs: !!seq []
+
+localcluster:
+  # level of log silencing (log messages of lower levels will
+  # be suppressed)
+  silence_logs: "WARNING"
+  # whether to use processes, single-core or threads
+  processes: True
+  # how many threads for each worker
+  threads_per_worker: 1
+
+
+############################### ROSETTA ###############################
+
+rosetta:
+  # usual Rosetta path for executables
+  execpath: "main/source/bin"
+  # suffix of the Rosetta executables
+  execsuffix: .mpi.linuxgccrelease


### PR DESCRIPTION
Added a new configuration file (`config_settings/rosettampi.yaml`) for when a user has Rosetta executables compiled with MPI but does not wish to use mpirun/mpiexec/etc. when launching them.