### PR TITLE
Fix 34 and 35 - aggregation when having multiple simultaneous mutations and MutateX-compatible outputs with the new cartddg2020 protocols

### DIFF
--- a/RosettaDDGPrediction/rosetta_ddg_aggregate.py
+++ b/RosettaDDGPrediction/rosetta_ddg_aggregate.py
@@ -413,9 +413,6 @@ def main():
     # For each mutation
     for i, (mut_name, dir_name, mut_label, pos_label) \
         in mutinfo.iterrows():
-
-        # Split the mutation name into its components
-        chain, wtr, numr, mutr = mut_name.split(COMP_SEP)
         
         # Get the mutation directory path
         mut_path = os.path.join(step_run_dir_path, dir_name)
@@ -561,6 +558,22 @@ def main():
         # If the conversion to MutateX-compatible outputs has been
         # requested
         if mutatex_convert:
+
+            # Try to split the mutation name into its components
+            try:
+
+                chain, wtr, numr, mutr = mut_name.split(COMP_SEP)
+
+            # If something went wrong, report it
+            except Exception as e:
+                
+                errstr = \
+                    f"Could not generate MutateX-compatible " \
+                    f"outputs for the mutation {mut_name}. " \
+                    f"Please note that the conversion does not " \
+                    f"work for multiple simultaneous mutations. "
+                log.error(errstr)
+                continue
             
             # Add the mutation's structures' data frame to the
             # corresponding position in the dictionary collecting the
@@ -607,7 +620,8 @@ def main():
                 client.submit(aggregation.write_mutatex_df,
                               dfs = dfs,
                               mutatex_file = mutatex_filepath,
-                              index = mutatex_restypes))
+                              index = mutatex_restypes,
+                              family = family))
 
     # Gather pending futures
     client.gather(futures)


### PR DESCRIPTION
This PR:

- [X] Solves a bug in aggregating raw outputs containing multiple simultaneous mutations.

- [X] When producing MutateX-compatible outputs from the raw data of `cartddg2020` protocols, in the first column reports the ddG value associated with the wild-type/mutant structure pair where the mutant has the lowest energy (among the mutants generated) instead of the average over the ddG values obtained on all pairs (which is the expected behavior for `cartddg` and `flexddg` protocols). The standard deviation column is filled with zeros, and the columns usually reporting the minimum and the maximum value found now report the same value as the first column.