### PR TITLE
Fix 38 - sequentially numbered mutinfo files when running multiple runs in the same output directory

### DIFF
--- a/RosettaDDGPrediction/util.py
+++ b/RosettaDDGPrediction/util.py
@@ -1229,6 +1229,35 @@ def write_mutinfo_file(mutations_original,
     data and plotting.
     """
 
+    # Get the name of the mutinfo file without the extension
+    mutinfo_filename, mutinfo_ext = os.path.splitext(mutinfo_file)
+
+    # Check if a mutinfo file with the name specified in
+    # the config file is already present (or others
+    # already numbered)
+    mutinfo_files = \
+        [f for f in os.listdir(step_wd) if f == mutinfo_file \
+         or re.match(f"{mutinfo_filename}[0-9]{mutinfo_ext}", f)]
+
+    # If (an)other mutinfo file(s) was (were) found
+    if mutinfo_files:
+
+        # Get the file numbers
+        num_files = \
+            [f.lstrip(mutinfo_filename).rstrip(mutinfo_ext) \
+             for f in mutinfo_files]
+
+        # Sort the file numbers
+        num_files_sorted = \
+            sorted([int(n) if n.isdigit() else 0 for n in num_files])
+
+        # Set the name of the new mutinfo file, given the files
+        # already found (name of the original mutinfo file name +
+        # higherst file number found+1 + original mutinfo file
+        # extension
+        mutinfo_file = \
+            f"{mutinfo_filename}{num_files_sorted[-1]+1}{mutinfo_ext}"
+
     # Set the path to the output file
     mutinfo_file_path = os.path.join(out_dir, mutinfo_file)
 


### PR DESCRIPTION
Fixes issue 38 where, for runs whose outputs were produced in the same directory and whose mutinfo files were named the same, the mutinfo file was overwritten each time.

Now, a new mutinfo file is produced for each of these runs, having the same name as the original mutinfo file but sequentially numbered. So, for example, if the name of the mutinfo file is defined as `mutinfo.txt` in the `config_run` file of the runs, the first mutinfo file produced will be called `mutinfo.txt,` the second will be called `mutinfo1.txt`, the third, `mutinfo2.txt`, etc.