### PR TITLE
Added YAML configuration files for running `cartddg2020` with the `talaris2014` scoring function

### DIFF
--- a/RosettaDDGPrediction/config_run/cartddg2020_talaris2014.yaml
+++ b/RosettaDDGPrediction/config_run/cartddg2020_talaris2014.yaml
@@ -1,0 +1,258 @@
+# Configuration file needed to run the `cartddg2020` protocol with
+# the `talaris2014_cart` scoring function.
+
+
+# version of the configuration file
+version: 1
+
+
+#--------------------- GENERAL PROTOCOL OPTIONS ----------------------#
+
+
+# family the protocol belongs to
+family: cartddg2020
+
+
+#------------------------ PDB-RELATED OPTIONS ------------------------#
+
+
+pdb:
+  # whether PDB files containing multiple chains are allowed
+  # (false for cartddg protocols since they are used to predict
+  # the ΔΔG of stability of monomeric proteins)
+  allow_multi_chains: False
+  # whether PDB files with chain IDs missing are allowed
+  # (true for cartddg protocols since chain IDs are not necessary,
+  # because they only deal with monomeric proteins)
+  allow_no_chain_ids: True
+
+
+#--------------------- MUTATIONS-RELATED OPTIONS ---------------------#
+
+
+# options regarding how mutations are defined in the mutations list
+# file
+mutations:
+  # which kind of residue numbering is used in defining mutations
+  # ("pose" for cartddg protocols since the 'mutfile' format used
+  # by them requires residue numbering to be consistent with the
+  # Rosetta pose numbering)
+  resnumbering: pose
+  # extra data associated with each mutation. For cartddg protocols,
+  # there are no extra data.
+  extra: !!null
+  # number of structures to be generated for each mutation. It is
+  # set to 'null' for cartddg protocols since they do generate 
+  # multiple structures but the option must be given as a
+  # Rosetta option (see -ddg:iterations below).
+  nstruct: !!null
+  # file mapping the names of the directories that will contain
+  # data for the mutations to the mutations themselves as specified
+  # in the mutations' list file. Will be written at the end of
+  # the run.
+  mutinfofile: mutinfo.txt
+
+
+#--------------------------- PROTOCOL STEPS --------------------------#
+
+
+steps:
+  # first step of the cartddg protocol
+  relax2020:
+    # name of the working directory where the step will be run
+    wd: relax
+    # whether (and how) to remove unnecessary files at the end
+    # of the run
+    cleanlevel: !!null
+    # name of the flags file(s) that will be written and used
+    # to run the step
+    flagsfile: flags.txt
+    # name of the Rosetta log file(s) that will be written
+    output: relax.out
+    # Rosetta options to be used in conjunction with the Rosetta
+    # executable
+    options:
+      
+      #------------------------ Input options ------------------------#
+      
+      # whether to ignore unrecognized residues found in the PDB
+      -in:ignore_unrecognized_res: True
+      # whether the PDB file will be read as a full-atom structure
+      # as opposed to coarse-grained (should not be changed)
+      -in:file:fullatom: True
+
+      #------------------------ Output options -----------------------#
+
+      # prefix for output structures' names
+      -out:prefix: relax_
+      # file containing the scores (will be written in the
+      # directory where the step is run if no path is specified)
+      -out:file:scorefile: scorefile.sc
+      # score file format (should not be changed since for now
+      # only text score files are parsed correctly. Rosetta default
+      # is 'text'.)
+      -out:file:scorefile_format: text
+
+      #------------------- Tracing/logging options -------------------#
+
+      # logging level. 300 is INFO level.
+      -out:level: 300
+      # whether to add tracer channel name to the output
+      -out:chname: True
+      # whether to add a timestamp to tracer channel name
+      -out:chtimestamp: True
+      # save modelling times for each model in seconds
+      -out:save_times: True
+
+      #------------------------- Run options -------------------------#
+
+      # whether to turn on/off checkpointing
+      -run:checkpoint: True
+      # whether to write out detailed version info, if it was 
+      # available at compile time
+      -run:version: True
+      # whether to discard coordinates information for missing density
+      # atoms (whose occupancy is zero) defined in the input structure
+      -run:ignore_zero_occupancy: False
+
+      #------------------- RosettaScripts options --------------------#
+
+      # protocol XML file
+      -parser:protocol: "Cartddg2020_relax.xml"
+      # variable substitutions for the XML parser, in the form
+      # of name=value
+      -parser:script_vars:
+        # how many cycles of relax should be performed
+        repeats: 4
+        # score function name
+        scfname: "talaris2014_cart"
+
+      #------------------ Scoring function options -------------------#
+
+      # scoring function weights
+      -score:weights: talaris2014_cart
+
+      #--------------------- Corrections options ---------------------#
+
+      # use the talaris score function and residue_type_set
+      -corrections:restore_talaris_behavior: True
+
+  # second step of the cartddg protocol
+  structure_selection:
+    # structure selection options
+    options:
+      # input file type (a Rosetta scorefile containing scores
+      # for a pool of structures)
+      infiletype: scorefile_text
+      # input file (output scorefile from the 'relax' step)
+      infile: relax/scorefile.sc
+      # selection criterion for the structure:
+      # - random: randomly draw a structure
+      # - lowest: select the structure with lowest energy
+      # - highest: select the structure with highest energy
+      # - closest_to_mean: select the structure whose energy
+      #                    is closest to the mean energy of
+      #                    the pool of structures
+      # - median: select the structure having median energy
+      # - first: select the structure computed first
+      # - last: select the structure computed last
+      select: lowest
+
+  # third step of the cartddg protocol
+  cartesian:
+    # name of the working directory where the step will be run
+    wd: cartesian
+    # whether (and how) to remove unnecessary files at the end
+    # of the run
+    cleanlevel: !!null
+    # name of the flags file(s) that will be written and used
+    # to run the step
+    flagsfile: flags.txt
+    # name of the Rosetta output file(s) that will be written
+    output: cartesian.out
+    # Rosetta options to be used in conjunction with the Rosetta
+    # executable  
+    options:
+
+      #------------------------ Input options ------------------------#
+      
+      # whether to ignore unrecognized residues found in the PDB
+      -in:ignore_unrecognized_res: True
+      # whether the PDB file will be read as a full-atom structure
+      # as opposed to coarse-grained (should not be changed)
+      -in:file:fullatom: True
+
+      #------------------- Tracing/logging options -------------------#
+
+      # logging level. 300 is INFO level.
+      -out:level: 300
+      # whether to add the tracer channel name to the output
+      -out:chname: True
+      # whether to add a timestamp to the tracer channel name
+      -out:chtimestamp: True
+      # whether to save modelling times for each model in seconds
+      -out:save_times: True
+
+      #------------------------- Run options -------------------------#
+
+      # whether to use checkpointing
+      -run:checkpoint: True
+      # whether to write out detailed version info, if it was 
+      # available at compile time
+      -run:version: True
+
+      #----------------------- Packing options -----------------------#
+
+      # file containing extra residue types to be included in the
+      # packing palette. 'null' if no file is specified (you can
+      # also comment out the option).
+      -packing:packer_palette:extra_base_type_file: !!null
+
+      #------------------------- DDG options -------------------------#
+
+      # whether to toggle on Cartesian mode
+      -ddg:cartesian: True
+      # how many (sequence) neighbors should be included in the 
+      # backbone minimization (Rosetta default is 1)
+      -ddg:bbnbrs: 1
+      # whether or not to dump repacked wild-type and mutant pdbs
+      -ddg:dump_pdbs: True
+      # name of the mutfile specifying the mutation
+      -ddg:mut_file: mutation.mutfile
+      # output file of predicted ΔΔGs
+      -ddg:out: mutation.ddg
+
+      # MADE EXPLICIT IN CARTDDG2020 - what is the score difference
+      # for two structures to be considered converged (the default
+      # has always been 1.0, but we make that explicit here)
+      -ddg:score_cutoff: 1.0
+      # MADE EXPLICIT IN CARTDDG2020 - how many fragments to pick,
+      # and then use, in the cartesian sampler
+      -ddg:nfrags: 30
+      # MADE EXPLICIT IN CARTDDG2020 - how many (sequence) neighbors
+      # should the fragments include
+      -ddg:frag_nbrs: 2
+      # CHANGED IN CARTDDG2020 - number of iterations of refinement
+      -ddg:iterations: 5
+      # NEW IN CARTDDG2020 - whether to force the ddg protocol to
+      # iterate up to the value set by -ddg:iterations rather than
+      # stopping at convergence
+      -ddg:force_iterations: False
+      # NEW IN CARTDDG2020 - whether to trigger the use of fragments
+      # and the cartesian sampler to optimize around proline residues
+      -ddg:optimize_proline: True
+      # NEW IN CARTDDG2020 - how many models need to be in range
+      # for the solution to be considered converged
+      -ddg:n_converged: 2
+
+      #------------------ Scoring function options -------------------#
+
+      # how far does the FA pair potential go out to
+      -score:fa_max_dis: 9.0
+      # scoring function weights
+      -score:weights: talaris2014_cart
+
+      #--------------------- Corrections options ---------------------#
+
+      # use the talaris score function and residue_type_set
+      -corrections:restore_talaris_behavior: True

--- a/RosettaDDGPrediction/config_run/cartesian2020_talaris2014.yaml
+++ b/RosettaDDGPrediction/config_run/cartesian2020_talaris2014.yaml
@@ -1,0 +1,157 @@
+# Configuration file needed to run the `cartesian` step of the
+# `cartddg` protocol with the `talaris2014_cart` scoring function.
+
+
+# version of the configuration file
+version: 1
+
+
+#--------------------- GENERAL PROTOCOL OPTIONS ----------------------#
+
+
+# family the protocol belongs to
+family: cartddg2020
+
+
+#------------------------ PDB-RELATED OPTIONS ------------------------#
+
+
+pdb:
+  # whether PDB files containing multiple chains are allowed
+  # (false for cartddg protocols since they are used to predict
+  # the ΔΔG of stability of monomeric proteins)
+  allow_multi_chains: False
+  # whether PDB files with chain IDs missing are allowed
+  # (true for cartddg protocols since chain IDs are not necessary,
+  # because they only deal with monomeric proteins)
+  allow_no_chain_ids: True
+
+
+#--------------------- MUTATIONS-RELATED OPTIONS ---------------------#
+
+
+# options regarding how mutations are defined in the mutations list
+# file
+mutations:
+  # which kind of residue numbering is used in defining mutations
+  # ("pose" for cartddg protocols since the 'mutfile' format used
+  # by them requires residue numbering to be consistent with the
+  # Rosetta pose numbering)
+  resnumbering: pose
+  # extra data associated with each mutation. For cartddg protocols,
+  # there are no extra data.
+  extra: !!null
+  # number of structures to be generated for each mutation. It is
+  # set to 'null' for cartddg protocols since they do generate 
+  # multiple structures but the option must be given as a
+  # Rosetta option (see -ddg:iterations below).
+  nstruct: !!null
+  # file mapping the names of the directories that will contain
+  # data for the mutations to the mutations themselves as specified
+  # in the mutations' list file. Will be written at the end of
+  # the run.
+  mutinfofile: mutinfo.txt
+
+
+#--------------------------- PROTOCOL STEPS --------------------------#
+
+
+steps:
+  # third step of the cartddg protocol
+  cartesian:
+    # name of the working directory where the step will be run
+    wd: cartesian
+    # whether (and how) to remove unnecessary files at the end
+    # of the run
+    cleanlevel: !!null
+    # name of the flags file(s) that will be written and used
+    # to run the step
+    flagsfile: flags.txt
+    # name of the Rosetta output file(s) that will be written
+    output: cartesian.out
+    # Rosetta options to be used in conjunction with the Rosetta
+    # executable  
+    options:
+
+      #------------------------ Input options ------------------------#
+      
+      # whether to ignore unrecognized residues found in the PDB
+      -in:ignore_unrecognized_res: True
+      # whether the PDB file will be read as a full-atom structure
+      # as opposed to coarse-grained (should not be changed)
+      -in:file:fullatom: True
+
+      #------------------- Tracing/logging options -------------------#
+
+      # logging level. 300 is INFO level.
+      -out:level: 300
+      # whether to add the tracer channel name to the output
+      -out:chname: True
+      # whether to add a timestamp to the tracer channel name
+      -out:chtimestamp: True
+      # whether to save modelling times for each model in seconds
+      -out:save_times: True
+
+      #------------------------- Run options -------------------------#
+
+      # whether to use checkpointing
+      -run:checkpoint: True
+      # whether to write out detailed version info, if it was 
+      # available at compile time
+      -run:version: True
+
+      #----------------------- Packing options -----------------------#
+
+      # file containing extra residue types to be included in the
+      # packing palette. 'null' if no file is specified (you can
+      # also comment out the option).
+      -packing:packer_palette:extra_base_type_file: !!null
+
+      #------------------------- DDG options -------------------------#
+
+      # whether to toggle on Cartesian mode
+      -ddg:cartesian: True
+      # how many (sequence) neighbors should be included in the 
+      # backbone minimization (Rosetta default is 1)
+      -ddg:bbnbrs: 1
+      # whether or not to dump repacked wild-type and mutant pdbs
+      -ddg:dump_pdbs: True
+      # name of the mutfile specifying the mutation
+      -ddg:mut_file: mutation.mutfile
+      # output file of predicted ΔΔGs
+      -ddg:out: mutation.ddg
+
+      # MADE EXPLICIT IN CARTDDG2020 - what is the score difference
+      # for two structures to be considered converged (the default
+      # has always been 1.0, but we make that explicit here)
+      -ddg:score_cutoff: 1.0
+      # MADE EXPLICIT IN CARTDDG2020 - how many fragments to pick,
+      # and then use, in the cartesian sampler
+      -ddg:nfrags: 30
+      # MADE EXPLICIT IN CARTDDG2020 - how many (sequence) neighbors
+      # should the fragments include
+      -ddg:frag_nbrs: 2
+      # CHANGED IN CARTDDG2020 - number of iterations of refinement
+      -ddg:iterations: 5
+      # NEW IN CARTDDG2020 - whether to force the ddg protocol to
+      # iterate up to the value set by -ddg:iterations rather than
+      # stopping at convergence
+      -ddg:force_iterations: False
+      # NEW IN CARTDDG2020 - whether to trigger the use of fragments
+      # and the cartesian sampler to optimize around proline residues
+      -ddg:optimize_proline: True
+      # NEW IN CARTDDG2020 - how many models need to be in range
+      # for the solution to be considered converged
+      -ddg:n_converged: 2
+
+      #------------------ Scoring function options -------------------#
+
+      # how far does the FA pair potential go out to
+      -score:fa_max_dis: 9.0
+      # scoring function weights
+      -score:weights: talaris2014_cart
+
+      #--------------------- Corrections options ---------------------#
+
+      # use the talaris score function and residue_type_set
+      -corrections:restore_talaris_behavior: True

--- a/RosettaDDGPrediction/config_run/relax2020_talaris2014.yaml
+++ b/RosettaDDGPrediction/config_run/relax2020_talaris2014.yaml
@@ -1,0 +1,112 @@
+# Configuration file needed to run the `relax` step of the
+# `cartddg2020` protocol with the `talaris2014_cart` scoring function.
+
+
+# version of the configuration file
+version: 1
+
+
+#--------------------- GENERAL PROTOCOL OPTIONS ----------------------#
+
+
+# family the protocol belongs to
+family: cartddg2020
+
+
+#------------------------ PDB-RELATED OPTIONS ------------------------#
+
+
+pdb:
+  # whether PDB files containing multiple chains are allowed
+  # (false for cartddg protocols since they are used to predict
+  # the ΔΔG of stability of monomeric proteins)
+  allow_multi_chains: False
+  # whether PDB files with chain IDs missing are allowed
+  # (true for cartddg protocols since chain IDs are not necessary,
+  # because they only deal with monomeric proteins)
+  allow_no_chain_ids: True
+
+
+#--------------------------- PROTOCOL STEPS --------------------------#
+
+
+steps:
+  # first step of the cartddg protocol
+  relax2020:
+    # name of the working directory where the step will be run
+    wd: relax
+    # whether (and how) to remove unnecessary files at the end
+    # of the run
+    cleanlevel: !!null
+    # name of the flags file(s) that will be written and used
+    # to run the step
+    flagsfile: flags.txt
+    # name of the Rosetta log file(s) that will be written
+    output: relax.out
+    # Rosetta options to be used in conjunction with the Rosetta
+    # executable
+    options:
+      
+      #------------------------ Input options ------------------------#
+      
+      # whether to ignore unrecognized residues found in the PDB
+      -in:ignore_unrecognized_res: True
+      # whether the PDB file will be read as a full-atom structure
+      # as opposed to coarse-grained (should not be changed)
+      -in:file:fullatom: True
+
+      #------------------------ Output options -----------------------#
+
+      # prefix for output structures' names
+      -out:prefix: relax_
+      # file containing the scores (will be written in the
+      # directory where the step is run if no path is specified)
+      -out:file:scorefile: scorefile.sc
+      # score file format (should not be changed since for now
+      # only text score files are parsed correctly. Rosetta default
+      # is 'text'.)
+      -out:file:scorefile_format: text
+
+      #------------------- Tracing/logging options -------------------#
+
+      # logging level. 300 is INFO level.
+      -out:level: 300
+      # whether to add tracer channel name to the output
+      -out:chname: True
+      # whether to add a timestamp to tracer channel name
+      -out:chtimestamp: True
+      # save modelling times for each model in seconds
+      -out:save_times: True
+
+      #------------------------- Run options -------------------------#
+
+      # whether to turn on/off checkpointing
+      -run:checkpoint: True
+      # whether to write out detailed version info, if it was 
+      # available at compile time
+      -run:version: True
+      # whether to discard coordinates information for missing density
+      # atoms (whose occupancy is zero) defined in the input structure
+      -run:ignore_zero_occupancy: False
+
+      #------------------- RosettaScripts options --------------------#
+
+      # protocol XML file
+      -parser:protocol: "Cartddg2020_relax.xml"
+      # variable substitutions for the XML parser, in the form
+      # of name=value
+      -parser:script_vars:
+        # how many cycles of relax should be performed
+        repeats: 4
+        # score function name
+        scfname: "talaris2014_cart"
+
+      #------------------ Scoring function options -------------------#
+
+      # scoring function weights
+      -score:weights: talaris2014_cart
+
+      #--------------------- Corrections options ---------------------#
+
+      # use the talaris score function and residue_type_set
+      -corrections:restore_talaris_behavior: True


### PR DESCRIPTION
Added new YAML configuration files in the `config_run` folder to run the `cartddg2020` protocol or each of its steps with the `talaris2014` scoring function:

- `cartddg2020_talaris2014` to run the full protocol.
- `relax2020_talaris2014` to run the `relax` step.
- `cartesian2020_talaris2014` to run the `cartesian` step.