### PR TITLE
Fixed issue #62

### DIFF
--- a/RosettaDDGPrediction/aggregation.py
+++ b/RosettaDDGPrediction/aggregation.py
@@ -382,6 +382,15 @@ def generate_output_dataframes(dg_wt,
          state_col, scf_name_col]
     
 
+    #
+    # In some cases, 'struct_num_col' is parsed as string instead of integer.
+    # So, this line was added to force the conversion of values to integer.
+    #
+    # Added by @alexandrefassio to fix issue #62.
+    #
+    struct_df[struct_num_col] = struct_df[struct_num_col].astype('int64')
+
+
     # If the protocol is the updated version of the cartddg protocol
     if family == "cartddg2020":
 


### PR DESCRIPTION
As shown in issue #62, for some inputs, the function generate_output_dataframes() from aggregation.py was raising an error because values in column 'struct_num_col' were being cast as string, while the code expects integer values.

So to fix this issue, I added a code to force the casting of this column to integer at line #391.