### PR TITLE
fix: plotting not correctly checking `ticks` array for content

### DIFF
--- a/RosettaDDGPrediction/plotting.py
+++ b/RosettaDDGPrediction/plotting.py
@@ -473,7 +473,7 @@ def set_axis(ax,
                            **ticklabels_config)
         
         # If tick positions were provided
-        if ticks != []:       
+        if len(ticks) > 0:       
             
             # Set the axis boundaries
             ax.spines["left"].set_bounds(ticks[0],

--- a/RosettaDDGPrediction/plotting.py
+++ b/RosettaDDGPrediction/plotting.py
@@ -450,7 +450,7 @@ def set_axis(ax,
                            **ticklabels_config)
         
         # If tick positions were provided
-        if ticks != []:      
+        if len(ticks) > 0      
             
             # Set the axis boundaries
             ax.spines["bottom"].set_bounds(ticks[0],

--- a/RosettaDDGPrediction/plotting.py
+++ b/RosettaDDGPrediction/plotting.py
@@ -450,7 +450,7 @@ def set_axis(ax,
                            **ticklabels_config)
         
         # If tick positions were provided
-        if len(ticks) > 0      
+        if len(ticks) > 0:      
             
             # Set the axis boundaries
             ax.spines["bottom"].set_bounds(ticks[0],


### PR DESCRIPTION
With the current code, if I try to run a `rosetta_ddg_plot` command on Python 3.11, i get the following error:

Command: 
```
rosetta_ddg_plot -i ~/8FO8_aggregate/ddg_mutations_aggregate.csv -o ~/8FO8_aggregate/contributions_barplot.pdf -ca ~/RosettaDDGPrediction-master/RosettaDDGPrediction/config_aggregate/aggregate.yaml -cp ~/RosettaDDGPrediction-master/RosettaDDGPrediction/config_plot/contributions_barplot.yaml
```

Error:
```
ERROR:root:Could not plot the barplot : operands could not be broadcast together with shapes (5,) (0,)
Could not plot the barplot : operands could not be broadcast together with shapes (5,) (0,)
```

This is because the `ticks` value can be an numpy ndarray and a comparison against an empty array will not work and err as shown above. 

If this PR looks alright, I would suggest squash and merging.